### PR TITLE
fix: backport stability fixes from claude-config-pro

### DIFF
--- a/hooks/HOOKS.md
+++ b/hooks/HOOKS.md
@@ -167,6 +167,7 @@ PreToolUse:W/E  → test-gate.sh → mock-gate.sh → branch-guard.sh → doc-ga
 [Tool executes]
                     ↓
 PostToolUse:W/E → lint.sh → track.sh → code-review.sh → plan-validate.sh → test-runner.sh (async)
+PostToolUse:Task → post-task.sh (auto-verify on tester completion)
                     ↓
 SubagentStart   → subagent-start.sh (agent-specific context)
 SubagentStop    → check-planner.sh | check-implementer.sh | check-tester.sh | check-guardian.sh | check-explore.sh | check-general-purpose.sh
@@ -210,6 +211,7 @@ Hooks within the same event run **sequentially** in array order from settings.js
 | **skill-result.sh** | Skill | Reads `.skill-result.md` from forked skills, injects as `additionalContext` to parent session. Surfaces research/analysis results from `context: fork` skills (deep-research, decide, consume-content, prd) back to orchestrator. Truncates files over 4000 bytes. Deletes file after reading to prevent stale results. Exit 0 silently if file doesn't exist |
 | **webfetch-fallback.sh** | WebFetch | Fires when WebFetch tool fails (non-200 response or error). Suggests `mcp__fetch__fetch` as alternative fetch method. Exit 0 (advisory only) |
 | **playwright-cleanup.sh** | mcp__playwright__browser_snapshot | Cleanup after Playwright browser snapshots. Prevents stale browser state accumulation |
+| **post-task.sh** | Task | PostToolUse:Task handler that detects tester completions and performs auto-verify. Reads summary.md from the tester trace via the active-tester breadcrumb (PostToolUse lacks `last_assistant_message`), validates `AUTOVERIFY: CLEAN` signal with secondary checks (**High** confidence, no **Medium**/**Low**, no "Partially verified", no non-environmental "Not tested"), writes `verified` to proof-status at all three paths (worktree, orchestrator scoped, orchestrator legacy). Emits `AUTO-VERIFIED` directive in `additionalContext` on success. Replaces the dead SubagentStop:tester auto-verify path. Safety net: if proof-status is missing when tester completes, writes `needs-verification` so the manual approval flow can proceed |
 
 ### Session Lifecycle
 

--- a/hooks/check-implementer.sh
+++ b/hooks/check-implementer.sh
@@ -209,19 +209,16 @@ write_statusline_cache "$PROJECT_ROOT"
 
 ISSUES=()
 
-# Layer A: Inject trace summary into additionalContext when agent response is empty/minimal.
-# When an agent's final turn is a bare tool call (no accompanying text), Task tool returns
-# empty to the orchestrator. This block surfaces the trace summary via ISSUES so the
-# orchestrator always receives work context via system-reminder, even on silent returns.
+# Layer A: Surface trace context when agent response is short.
+# Short returns are normal under Trace Protocol — only flag when genuinely lost.
 # See DEC-SILENT-RETURN-001 in check-guardian.sh for rationale.
 if [[ ${#RESPONSE_TEXT} -lt 50 ]]; then
-    _inj_summary=""
+    _has_trace="false"
     if [[ -n "$TRACE_DIR" && -f "$TRACE_DIR/summary.md" ]]; then
-        _inj_summary=$(head -c 2000 "$TRACE_DIR/summary.md" 2>/dev/null || echo "")
+        _trace_size=$(wc -c < "$TRACE_DIR/summary.md" 2>/dev/null || echo 0)
+        [[ "$_trace_size" -gt 10 ]] && _has_trace="true"
     fi
-    if [[ -n "$_inj_summary" ]]; then
-        ISSUES+=("Agent returned minimal response. Trace summary: $_inj_summary")
-    else
+    if [[ "$_has_trace" == "false" && -z "${RESPONSE_TEXT// /}" ]]; then
         ISSUES+=("Agent returned no response and no trace summary available. Check git log for what happened.")
     fi
 fi

--- a/hooks/post-task.sh
+++ b/hooks/post-task.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# PostToolUse:Task — auto-verify migration from SubagentStop:tester.
+#
+# Fires after every Task tool completes. When the completed task was a tester
+# agent, reads the tester's summary.md from its trace directory (via the
+# .active-tester-* breadcrumb) and performs auto-verify secondary validation.
+#
+# If ALL conditions pass, writes verified status to three paths:
+#   1. Worktree proof-status (resolve_proof_file)
+#   2. Orchestrator scoped proof-status (.proof-status-{phash})
+#   3. Orchestrator legacy proof-status (.proof-status)
+#
+# Emits AUTO-VERIFIED directive in additionalContext on success.
+#
+# Secondary validation rules (mirrors check-tester.sh Phase 1):
+#   - AUTOVERIFY: CLEAN present in summary.md
+#   - **High** confidence (markdown bold)
+#   - NO **Medium** or **Low** confidence
+#   - NO "Partially verified"
+#   - NO non-environmental "Not tested" (environmental patterns whitelisted)
+#
+# PostToolUse:Task stdin format:
+#   {"tool_name":"Task","tool_input":{"subagent_type":"tester","prompt":"..."},"cwd":"..."}
+#
+# @decision DEC-PROOF-LIFE-001
+# @title New post-task.sh handler (not extending task-track.sh)
+# @status accepted
+# @rationale SubagentStop:tester does not fire reliably (confirmed dead event
+#   in practice). PostToolUse:Task fires after every Task tool call and contains
+#   the subagent_type in tool_input, enabling us to identify tester completions.
+#   Extending task-track.sh (PreToolUse:Task) would conflate pre/post semantics;
+#   a dedicated post-task.sh handler is cleaner and easier to test independently.
+#   Issue #150.
+#
+# @decision DEC-PROOF-LIFE-002
+# @title Read summary.md via tester breadcrumb (PostToolUse lacks last_assistant_message)
+# @status accepted
+# @rationale PostToolUse:Task stdin does not include the agent's response text
+#   (unlike SubagentStop which provides last_assistant_message). The AUTOVERIFY
+#   signal must be read from the tester's trace summary.md artifact, which the
+#   Trace Protocol requires the tester to write before returning. The active
+#   tester trace is found via detect_active_trace() or .active-tester-* marker
+#   files in TRACE_STORE. This is the same approach used by check-tester.sh's
+#   DEC-V3-001 summary.md fallback. Issue #150.
+
+set -euo pipefail
+
+source "$(dirname "$0")/source-lib.sh"
+
+HOOK_INPUT=$(read_input)
+TOOL_NAME=$(echo "$HOOK_INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+SUBAGENT_TYPE=$(echo "$HOOK_INPUT" | jq -r '.tool_input.subagent_type // empty' 2>/dev/null || echo "")
+
+# Only act on Task tool completions for the tester subagent
+if [[ "$TOOL_NAME" != "Task" || "$SUBAGENT_TYPE" != "tester" ]]; then
+    exit 0
+fi
+
+PROJECT_ROOT=$(detect_project_root)
+CLAUDE_DIR=$(get_claude_dir)
+
+log_info "POST-TASK" "tester Task completed — checking for AUTOVERIFY signal"
+
+# --- Resolve active proof-status file ---
+PROOF_FILE=$(resolve_proof_file)
+PROOF_STATUS="missing"
+if [[ -f "$PROOF_FILE" ]]; then
+    PROOF_STATUS=$(cut -d'|' -f1 "$PROOF_FILE")
+fi
+
+log_info "POST-TASK" "proof-status=$PROOF_STATUS proof_file=$PROOF_FILE"
+
+# --- Dedup guard: skip if already verified ---
+# Prevents double-write if PostToolUse fires multiple times for the same tester.
+if [[ "$PROOF_STATUS" == "verified" ]]; then
+    log_info "POST-TASK" "already verified — skipping (dedup guard)"
+    cat <<'EOF'
+{
+  "additionalContext": "post-task: tester completed, proof already verified (dedup guard — no action needed)."
+}
+EOF
+    exit 0
+fi
+
+# --- Safety net: if proof-status missing, create needs-verification ---
+# If somehow there is no proof-status file at all, create a needs-verification
+# entry so the approval flow can still proceed (mirrors check-tester.sh DEC-TESTER-003).
+if [[ "$PROOF_STATUS" == "missing" ]]; then
+    log_info "POST-TASK" "proof-status missing — writing needs-verification (safety net)"
+    mkdir -p "$(dirname "$PROOF_FILE")"
+    echo "needs-verification|$(date +%s)" > "$PROOF_FILE"
+    PROOF_STATUS="needs-verification"
+fi
+
+# --- Read tester summary.md from trace ---
+# PostToolUse lacks last_assistant_message; use TRACE_STORE to find summary.md.
+SUMMARY_TEXT=""
+_AV_TRACE_ID=$(detect_active_trace "$PROJECT_ROOT" "tester" 2>/dev/null || echo "")
+
+if [[ -n "$_AV_TRACE_ID" ]]; then
+    _AV_SUMMARY="${TRACE_STORE}/${_AV_TRACE_ID}/summary.md"
+    log_info "POST-TASK" "found active tester trace=${_AV_TRACE_ID}"
+    if [[ -s "$_AV_SUMMARY" ]]; then
+        _SUMMARY_SIZE=$(wc -c < "$_AV_SUMMARY" 2>/dev/null || echo 0)
+        if [[ "$_SUMMARY_SIZE" -ge 10 ]]; then
+            SUMMARY_TEXT=$(cat "$_AV_SUMMARY" 2>/dev/null || echo "")
+            log_info "POST-TASK" "loaded summary.md size=$_SUMMARY_SIZE"
+        else
+            log_info "POST-TASK" "summary.md too small (${_SUMMARY_SIZE} bytes) — likely empty"
+        fi
+    else
+        log_info "POST-TASK" "summary.md not found or empty at ${_AV_SUMMARY}"
+    fi
+else
+    log_info "POST-TASK" "no active tester trace found — cannot read summary.md"
+fi
+
+# No summary available — cannot auto-verify, exit gracefully
+if [[ -z "$SUMMARY_TEXT" ]]; then
+    log_info "POST-TASK" "no summary.md content available — skipping auto-verify"
+    exit 0
+fi
+
+# --- Check for AUTOVERIFY: CLEAN signal ---
+if ! echo "$SUMMARY_TEXT" | grep -q 'AUTOVERIFY: CLEAN'; then
+    log_info "POST-TASK" "AUTOVERIFY: CLEAN not found in summary.md — skipping"
+    exit 0
+fi
+
+log_info "POST-TASK" "AUTOVERIFY: CLEAN found — running secondary validation"
+
+# --- Secondary validation (mirrors check-tester.sh lines 194-232) ---
+AV_FAIL=false
+NOT_TESTED_LINES=""
+WHITELISTED_COUNT=0
+
+# Must have **High** confidence (markdown bold)
+if ! echo "$SUMMARY_TEXT" | grep -qi '\*\*High\*\*'; then
+    log_info "POST-TASK" "secondary validation FAIL: missing **High** confidence"
+    AV_FAIL=true
+fi
+
+# Must NOT have "Partially verified"
+if echo "$SUMMARY_TEXT" | grep -qi 'Partially verified'; then
+    log_info "POST-TASK" "secondary validation FAIL: 'Partially verified' found"
+    AV_FAIL=true
+fi
+
+# Must NOT have **Medium** or **Low** confidence
+if echo "$SUMMARY_TEXT" | grep -qi '\*\*Medium\*\*\|\*\*Low\*\*'; then
+    log_info "POST-TASK" "secondary validation FAIL: Medium or Low confidence found"
+    AV_FAIL=true
+fi
+
+# Must NOT have non-environmental "Not tested" entries
+# Environmental patterns are whitelisted — they cannot be tested in a headless CLI context
+ENV_PATTERN='requires browser\|requires viewport\|requires screen reader\|requires mobile\|requires physical device\|requires hardware\|requires manual interaction\|requires human interaction\|requires GUI\|requires native app\|requires network'
+NOT_TESTED_LINES=$(echo "$SUMMARY_TEXT" | grep -i 'Not tested' || true)
+if [[ -n "$NOT_TESTED_LINES" ]]; then
+    NON_ENV_LINES=$(echo "$NOT_TESTED_LINES" | grep -iv "$ENV_PATTERN" || true)
+    if [[ -n "$NON_ENV_LINES" ]]; then
+        log_info "POST-TASK" "secondary validation FAIL: non-environmental 'Not tested' found: $NON_ENV_LINES"
+        AV_FAIL=true
+    else
+        # Count whitelisted environmental items
+        WHITELISTED_COUNT=$(echo "$NOT_TESTED_LINES" | grep -ic "$ENV_PATTERN" 2>/dev/null || echo "0")
+        log_info "POST-TASK" "secondary validation: ${WHITELISTED_COUNT} environmental 'Not tested' item(s) whitelisted"
+    fi
+fi
+
+# --- Apply result ---
+if [[ "$AV_FAIL" == "true" ]]; then
+    log_info "POST-TASK" "secondary validation FAILED — proof stays $PROOF_STATUS"
+    append_audit "$PROJECT_ROOT" "auto_verify_rejected" "post-task: AUTOVERIFY: CLEAN found but secondary validation failed (proof=$PROOF_STATUS)"
+    exit 0
+fi
+
+# All checks passed — write verified to all three paths
+TS=$(date +%s)
+echo "verified|${TS}" > "$PROOF_FILE"
+
+# Dual-write: keep orchestrator's scoped and legacy copies in sync
+# so guard.sh can find it regardless of which path it checks.
+_PHASH=$(project_hash "$PROJECT_ROOT")
+ORCH_SCOPED_PROOF="${CLAUDE_DIR}/.proof-status-${_PHASH}"
+ORCH_PROOF="${CLAUDE_DIR}/.proof-status"
+
+if [[ "$PROOF_FILE" != "$ORCH_SCOPED_PROOF" ]]; then
+    echo "verified|${TS}" > "$ORCH_SCOPED_PROOF"
+fi
+if [[ "$PROOF_FILE" != "$ORCH_PROOF" && "$ORCH_SCOPED_PROOF" != "$ORCH_PROOF" ]]; then
+    echo "verified|${TS}" > "$ORCH_PROOF"
+fi
+
+# Audit trail
+if [[ "${WHITELISTED_COUNT:-0}" -gt 0 ]]; then
+    append_audit "$PROJECT_ROOT" "auto_verify" "post-task: AUTOVERIFY: CLEAN — secondary validation passed, proof auto-verified (${WHITELISTED_COUNT} environmental 'Not tested' item(s) whitelisted)"
+else
+    append_audit "$PROJECT_ROOT" "auto_verify" "post-task: AUTOVERIFY: CLEAN — secondary validation passed, proof auto-verified"
+fi
+
+log_info "POST-TASK" "AUTO-VERIFIED — proof written to $PROOF_FILE"
+
+# Emit directive
+CONTEXT="post-task: tester Task completed — proof auto-verified (AUTOVERIFY: CLEAN, secondary validation passed)."
+DIRECTIVE="AUTO-VERIFIED: Tester e2e verification passed — High confidence, full coverage, no caveats. .proof-status is verified. Dispatch Guardian NOW with 'AUTO-VERIFY-APPROVED' in the prompt. Guardian will skip its approval prompt and execute the full merge cycle directly. Present the tester's verification report to the user in parallel."
+ESCAPED=$(printf '%s\n\n%s' "$CONTEXT" "$DIRECTIVE" | jq -Rs .)
+cat <<EOF
+{
+  "additionalContext": $ESCAPED
+}
+EOF
+exit 0

--- a/hooks/task-track.sh
+++ b/hooks/task-track.sh
@@ -159,6 +159,23 @@ if [[ "$AGENT_TYPE" == "tester" ]]; then
             fi
         fi
     fi
+
+    # Initialize tester trace so post-task.sh can find it via detect_active_trace().
+    # SubagentStart (which normally calls init_trace) doesn't fire (DEC-CACHE-003),
+    # so init_trace() for testers never runs via the normal path.
+    # Gate C already initializes implementer traces — this mirrors that pattern for testers.
+    # post-task.sh reads the .active-tester-* marker to locate summary.md for auto-verify.
+    #
+    # @decision DEC-PROOF-LIFE-004
+    # @title Initialize tester trace in task-track.sh (PreToolUse:Task) for post-task.sh breadcrumb
+    # @status accepted
+    # @rationale SubagentStart doesn't fire (DEC-CACHE-003), so init_trace() for testers
+    #   never runs. post-task.sh needs the .active-tester-* marker to find summary.md.
+    #   Gate C already initializes implementer traces — this mirrors that pattern for testers.
+    TESTER_TRACE_ID=$(init_trace "$PROJECT_ROOT" "tester" 2>/dev/null || echo "")
+    if [[ -n "$TESTER_TRACE_ID" ]]; then
+        log_info "TASK-TRACK" "initialized tester trace=${TESTER_TRACE_ID}"
+    fi
 fi
 
 # --- Gate C: Implementer dispatch activates proof gate ---

--- a/settings.json
+++ b/settings.json
@@ -238,6 +238,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/post-task.sh",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "Notification": [


### PR DESCRIPTION
## Summary

Backports critical bug fixes and infrastructure stability improvements from the private claude-config-pro repo to the public claude-ctrl repo.

### Cat 1: Bug Fixes

- **Guard worktree infinite loop** — Checks 5/5b unconditionally denied all worktree removal commands, including corrected resubmissions. Every retry got denied again with another `cd` prepended — infinite loop. Fix: gate deny on CWD being inside a worktree path (the only dangerous case).

- **Empty prompt spam** — `prompt-submit.sh` silently exited on Enter-only submits, giving the model no guidance. All four `check-*.sh` hooks flagged short agent returns (<50 chars) as persistent "minimal response" issues, causing the model to repeatedly comment on "empty messages." Fix: inject continuation hint on empty prompts (DEC-PROMPT-002), and only flag agent returns when genuinely lost (no trace AND no response).

### Cat 2: Auto-verify Infrastructure Stability

- **Auto-verify migration** — The auto-verify fast path in `check-tester.sh` depends on `SubagentStop:tester`, which never fires in Claude Code (dead event). Every clean tester verification required manual user approval. Fix: new `post-task.sh` handler on `PostToolUse:Task` (which does fire), with trace breadcrumb-based summary reading and secondary validation. Tester trace init added to `task-track.sh` since `SubagentStart` also doesn't fire. Dead code in `check-tester.sh` preserved with `@deprecated` annotations.

## Files Changed (10)

| File | Change |
|------|--------|
| `hooks/guard.sh` | CWD-conditional deny in Checks 5/5b |
| `hooks/prompt-submit.sh` | Empty prompt continuation hint |
| `hooks/check-guardian.sh` | Revised silent return detection |
| `hooks/check-implementer.sh` | Revised silent return detection |
| `hooks/check-planner.sh` | Revised silent return detection |
| `hooks/check-tester.sh` | Revised silent return + @deprecated annotations |
| `hooks/post-task.sh` | NEW — PostToolUse:Task auto-verify handler |
| `hooks/task-track.sh` | Tester trace init breadcrumb |
| `hooks/HOOKS.md` | PostToolUse:Task documentation |
| `settings.json` | PostToolUse Task matcher registration |

## Test plan

- [x] All modified .sh files pass `bash -n` syntax check
- [ ] Guard worktree removal works when CWD is safe (no infinite loop)
- [ ] Enter-only submits produce continuation hint, not error
- [ ] Short agent returns with trace summary don't flag as issues
- [ ] Auto-verify fires on PostToolUse:Task for clean tester completions
