### PR TITLE
fix(post-task): preserve subagent marker for background dispatches (Gate 1.5 unblock)

### DIFF
--- a/hooks/post-task.sh
+++ b/hooks/post-task.sh
@@ -180,29 +180,74 @@ DIAG
     log_info "POST-TASK" "wrote diagnostic summary for ${agent_type} at ${sum_file}"
 }
 
+# --- Background-dispatch guard (DEC-POST-TASK-BG-DISPATCH-001) ---
+# When run_in_background=true, PostToolUse:Task fires the moment the tool call
+# returns an agentId — the subagent is still running. Calling finalize_trace here
+# would delete the .active-<type>-<sid>-<phash> marker while the subagent is live.
+# pre-write.sh Gate 1.5 checks for this marker to allow implementer source writes;
+# removing it early causes all Write/Edit calls from the subagent to be blocked with
+# "Source writes from orchestrator context."
+#
+# Discriminator: tool_input.run_in_background is the flag the orchestrator passes
+# when dispatching a background subagent. It appears in HOOK_INPUT.tool_input exactly
+# as the caller specified it. When absent or false, this is a foreground dispatch
+# (tool call blocks until the agent returns) — the existing fallback is correct.
+#
+# Risk: if SubagentStop fails to fire for a bg subagent, the marker leaks until the
+# next session or a manual stale-marker sweep. This is acceptable: a leaked marker
+# causes a false-allow (benign) rather than a false-deny (the pre-existing bug).
+# Future work: implement a periodic stale-marker sweep in session-end.sh that removes
+# markers older than the configured stale_threshold (1800s default in trace-lib.sh).
+#
+# @decision DEC-POST-TASK-BG-DISPATCH-001
+# @title Skip fallback finalize for background-dispatch returns
+# @status accepted
+# @rationale PostToolUse:Task fires twice for background subagents: (1) immediately
+#   when the orchestrator's Task call returns an agentId (bg dispatch return), and
+#   (2) never — because SubagentStop is the canonical completion event. The existing
+#   fallback finalization (detect_active_trace + finalize_trace) was designed for the
+#   case where SubagentStop does not fire (documented unreliability, DEC-PROOF-LIFE-001).
+#   For bg dispatches, this premature finalization deletes the .active-* marker that
+#   pre-write.sh Gate 1.5 requires to permit source writes from implementer subagents.
+#   Fix: detect tool_input.run_in_background==true and skip finalize_trace. The actual
+#   finalization will happen when SubagentStop fires. For fg dispatches (bg==false or
+#   absent), the existing fallback runs unchanged — SubagentStop unreliability still
+#   applies there.
+_IS_BG_DISPATCH=$(echo "$HOOK_INPUT" | jq -r '.tool_input.run_in_background // false' 2>/dev/null || echo "false")
+
 _fb_trace_id=""  # Initialize for use in implementer section below (DEC-CYCLE-DETECT-001)
 if [[ "$IS_SUBAGENT" == "true" && "$SUBAGENT_TYPE" != "tester" && -n "$SUBAGENT_TYPE" ]]; then
-    _fb_project_root=$(detect_project_root 2>/dev/null || echo "")
-    if [[ -n "$_fb_project_root" ]]; then
-        _fb_trace_id=$(detect_active_trace "$_fb_project_root" "$SUBAGENT_TYPE" 2>/dev/null || echo "")
-        if [[ -n "$_fb_trace_id" ]]; then
-            _fb_trace_dir="${TRACE_STORE}/${_fb_trace_id}"
-            log_info "POST-TASK" "fallback: detected active ${SUBAGENT_TYPE} trace ${_fb_trace_id} — writing diagnostic summary + finalizing"
-            _write_diagnostic_summary "$_fb_trace_dir" "$SUBAGENT_TYPE" "$_fb_project_root"
-            finalize_trace "$_fb_trace_id" "$_fb_project_root" "$SUBAGENT_TYPE" 2>/dev/null || true
-            log_info "POST-TASK" "fallback: trace finalized for agent_type=${SUBAGENT_TYPE}"
-            append_audit "$_fb_project_root" "post_task_fallback_finalize" \
-                "agent_type=${SUBAGENT_TYPE} trace=${_fb_trace_id}" 2>/dev/null || true
-            # Emit additionalContext for non-implementer agents (implementer gets its own
-            # DISPATCH TESTER NOW directive below — do not exit here for implementers).
-            if [[ "$SUBAGENT_TYPE" != "implementer" ]]; then
-                _fb_summary=$(head -c 2000 "${TRACE_STORE}/${_fb_trace_id}/summary.md" 2>/dev/null || echo "")
-                if [[ -n "$_fb_summary" ]]; then
-                    _fb_escaped=$(printf 'post-task fallback (%s): %s' "$SUBAGENT_TYPE" "$_fb_summary" | jq -Rs .)
-                    cat <<EOF
+    # Background dispatch: the subagent is still running — skip finalize to preserve marker.
+    # SubagentStop is the canonical finalize event for background subagents.
+    if [[ "$_IS_BG_DISPATCH" == "true" ]]; then
+        log_info "POST-TASK" "bg dispatch return for ${SUBAGENT_TYPE} — skipping fallback finalize (subagent still running, marker preserved for Gate 1.5)"
+        append_audit "$(detect_project_root 2>/dev/null || echo /)" "post_task_bg_dispatch_skip" \
+            "agent_type=${SUBAGENT_TYPE} bg=true — finalize deferred to SubagentStop" 2>/dev/null || true
+        # Fall through: do NOT finalize, do NOT write summary.md (subagent hasn't completed yet).
+        # The implementer directive below (lines 230+) still runs for bg implementer dispatches.
+    else
+        _fb_project_root=$(detect_project_root 2>/dev/null || echo "")
+        if [[ -n "$_fb_project_root" ]]; then
+            _fb_trace_id=$(detect_active_trace "$_fb_project_root" "$SUBAGENT_TYPE" 2>/dev/null || echo "")
+            if [[ -n "$_fb_trace_id" ]]; then
+                _fb_trace_dir="${TRACE_STORE}/${_fb_trace_id}"
+                log_info "POST-TASK" "fallback: detected active ${SUBAGENT_TYPE} trace ${_fb_trace_id} — writing diagnostic summary + finalizing"
+                _write_diagnostic_summary "$_fb_trace_dir" "$SUBAGENT_TYPE" "$_fb_project_root"
+                finalize_trace "$_fb_trace_id" "$_fb_project_root" "$SUBAGENT_TYPE" 2>/dev/null || true
+                log_info "POST-TASK" "fallback: trace finalized for agent_type=${SUBAGENT_TYPE}"
+                append_audit "$_fb_project_root" "post_task_fallback_finalize" \
+                    "agent_type=${SUBAGENT_TYPE} trace=${_fb_trace_id}" 2>/dev/null || true
+                # Emit additionalContext for non-implementer agents (implementer gets its own
+                # DISPATCH TESTER NOW directive below — do not exit here for implementers).
+                if [[ "$SUBAGENT_TYPE" != "implementer" ]]; then
+                    _fb_summary=$(head -c 2000 "${TRACE_STORE}/${_fb_trace_id}/summary.md" 2>/dev/null || echo "")
+                    if [[ -n "$_fb_summary" ]]; then
+                        _fb_escaped=$(printf 'post-task fallback (%s): %s' "$SUBAGENT_TYPE" "$_fb_summary" | jq -Rs .)
+                        cat <<EOF
 { "additionalContext": $_fb_escaped }
 EOF
-                    exit 0
+                        exit 0
+                    fi
                 fi
             fi
         fi

--- a/tests/test-post-task-bg-dispatch.sh
+++ b/tests/test-post-task-bg-dispatch.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+# Test post-task.sh background-dispatch guard (DEC-POST-TASK-BG-DISPATCH-001).
+#
+# The bug: when a subagent is dispatched with run_in_background=true, PostToolUse:Task
+# fires immediately (the tool returns an agentId) while the subagent keeps running.
+# The fallback finalize block (lines 183-209) was calling finalize_trace on the just-
+# created active trace — deleting the .active-<type>-<sid>-<phash> marker. The subagent
+# then continues without a marker. pre-write.sh Gate 1.5 sees no marker and blocks
+# source writes with "orchestrator context" error.
+#
+# Fix: detect tool_input.run_in_background == true and skip finalize_trace for bg
+# dispatches. SubagentStop is the canonical finalize for background subagents.
+#
+# Validates:
+#   1. Background dispatch (run_in_background=true): finalize_trace NOT called, marker survives
+#   2. Foreground dispatch (run_in_background absent/false): existing fallback path still fires
+#   3. post-task.sh has @decision DEC-POST-TASK-BG-DISPATCH-001 annotation
+#   4. Smoke test: hook syntax still valid after fix
+#
+# @decision DEC-TEST-POST-TASK-BG-DISPATCH-001
+# @title Test suite for background-dispatch finalization guard in post-task.sh
+# @status accepted
+# @rationale The bg-dispatch bug blocked every background-dispatched implementer from
+#   writing source code. These tests verify the fix: bg dispatches skip finalize_trace
+#   (marker survives for the subagent's full duration), while foreground dispatches
+#   continue through the existing fallback path unchanged. Tests run against the actual
+#   post-task.sh code — no mocks of internal functions — with a real TRACE_STORE
+#   fixture matching the marker format used by subagent-start.sh. Issue: bg-dispatch bug.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOKS_DIR="$PROJECT_ROOT/hooks"
+
+# Ensure tmp directory exists
+mkdir -p "$PROJECT_ROOT/tmp"
+
+# Cleanup trap: collect temp dirs and remove on exit
+_CLEANUP_DIRS=()
+trap '[[ ${#_CLEANUP_DIRS[@]} -gt 0 ]] && rm -rf "${_CLEANUP_DIRS[@]}" 2>/dev/null; true' EXIT
+
+# Track test results
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+run_test() {
+    local test_name="$1"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    echo "Running: $test_name"
+}
+
+pass_test() {
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo "  PASS"
+}
+
+fail_test() {
+    local reason="$1"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo "  FAIL: $reason"
+}
+
+# Helper: compute project_hash for a given path (same algorithm as source-lib.sh)
+# Uses the actual hook source to guarantee consistency.
+compute_phash() {
+    local path="$1"
+    bash -c "source '$HOOKS_DIR/source-lib.sh' && project_hash '$path'" 2>/dev/null || echo "testhash"
+}
+
+# Helper: set up a real fake trace environment with active marker.
+# Uses the actual REAL_PROJECT_ROOT (what detect_project_root would return) so
+# that post-task.sh's detect_project_root() → detect_active_trace() chain finds
+# the marker. The manifest project field must match this root.
+#
+# Args: agent_type test_dir session_id
+# Returns (stdout): trace_id
+setup_bg_trace_env() {
+    local agent_type="$1"
+    local test_dir="$2"
+    local session_id="$3"
+    # post-task.sh calls detect_project_root() which returns the real ~/.claude root,
+    # not the worktree. Use the real root for the project field in manifest.json so
+    # detect_active_trace() can find the trace by project match.
+    local real_root
+    real_root=$(bash -c "source '$HOOKS_DIR/source-lib.sh' && detect_project_root 2>/dev/null" 2>/dev/null \
+        || echo "$PROJECT_ROOT")
+
+    export TRACE_STORE="$test_dir/traces"
+    export CLAUDE_SESSION_ID="$session_id"
+    mkdir -p "$TRACE_STORE"
+
+    local timestamp
+    timestamp=$(date +%Y%m%d-%H%M%S)
+    local trace_id="${agent_type}-${timestamp}-bgtest"
+    local trace_dir="${TRACE_STORE}/${trace_id}"
+    mkdir -p "${trace_dir}/artifacts"
+
+    cat > "${trace_dir}/manifest.json" <<MANIFEST
+{
+  "version": "1",
+  "trace_id": "${trace_id}",
+  "agent_type": "${agent_type}",
+  "session_id": "${session_id}",
+  "project": "${real_root}",
+  "project_name": ".claude",
+  "branch": "main",
+  "start_commit": "",
+  "started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "status": "active"
+}
+MANIFEST
+
+    # Write .active-<agent_type>-<session_id>-<phash> marker (project-scoped format)
+    local phash
+    phash=$(compute_phash "$real_root")
+    echo "${trace_id}" > "${TRACE_STORE}/.active-${agent_type}-${session_id}-${phash}"
+
+    echo "$trace_id"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: Background dispatch (run_in_background=true) does NOT finalize trace
+#
+# The active marker must survive after post-task.sh runs, because the subagent
+# is still running. finalize_trace deletes the marker — if we skip finalize,
+# the marker file remains.
+# ---------------------------------------------------------------------------
+run_test "BG dispatch: active marker survives (finalize_trace skipped)"
+
+TEST_DIR=$(mktemp -d "$PROJECT_ROOT/tmp/test-ptbg-XXXXXX")
+_CLEANUP_DIRS+=("$TEST_DIR")
+SESSION_ID="test-bg-marker-$$"
+
+TRACE_ID=$(setup_bg_trace_env "implementer" "$TEST_DIR" "$SESSION_ID")
+
+# Compute the expected marker path
+REAL_ROOT=$(bash -c "source '$HOOKS_DIR/source-lib.sh' && detect_project_root 2>/dev/null" 2>/dev/null || echo "$PROJECT_ROOT")
+PHASH=$(compute_phash "$REAL_ROOT")
+MARKER_PATH="${TEST_DIR}/traces/.active-implementer-${SESSION_ID}-${PHASH}"
+
+# Verify marker exists before
+if [[ ! -f "$MARKER_PATH" ]]; then
+    fail_test "precondition: marker not created at $MARKER_PATH"
+else
+    # Run post-task.sh with run_in_background=true
+    printf '{"tool_name":"Agent","tool_input":{"subagent_type":"implementer","run_in_background":true},"cwd":"%s"}' \
+        "$REAL_ROOT" \
+        | env TRACE_STORE="${TEST_DIR}/traces" \
+              CLAUDE_SESSION_ID="$SESSION_ID" \
+              CLAUDE_DIR="$TEST_DIR/.claude" \
+          bash "$HOOKS_DIR/post-task.sh" >/dev/null 2>&1 || true
+
+    # Marker must still exist after bg dispatch return
+    if [[ -f "$MARKER_PATH" ]]; then
+        pass_test
+    else
+        fail_test "marker was deleted for bg dispatch! Gate 1.5 would block source writes. Path: $MARKER_PATH"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: Foreground dispatch (run_in_background absent) DOES go through fallback
+#
+# For a foreground dispatch, the existing fallback path should still detect the
+# active trace and write a diagnostic summary.md (just as before the fix).
+# ---------------------------------------------------------------------------
+run_test "FG dispatch: fallback path still fires (summary.md written)"
+
+TEST_DIR=$(mktemp -d "$PROJECT_ROOT/tmp/test-ptbg-XXXXXX")
+_CLEANUP_DIRS+=("$TEST_DIR")
+SESSION_ID="test-fg-fallback-$$"
+
+TRACE_ID=$(setup_bg_trace_env "guardian" "$TEST_DIR" "$SESSION_ID")
+TRACE_DIR_FG="${TEST_DIR}/traces/${TRACE_ID}"
+
+REAL_ROOT=$(bash -c "source '$HOOKS_DIR/source-lib.sh' && detect_project_root 2>/dev/null" 2>/dev/null || echo "$PROJECT_ROOT")
+
+printf '{"tool_name":"Agent","tool_input":{"subagent_type":"guardian"},"cwd":"%s"}' \
+    "$REAL_ROOT" \
+    | env TRACE_STORE="${TEST_DIR}/traces" \
+          CLAUDE_SESSION_ID="$SESSION_ID" \
+          CLAUDE_DIR="$TEST_DIR/.claude" \
+      bash "$HOOKS_DIR/post-task.sh" >/dev/null 2>&1 || true
+
+if [[ -f "${TRACE_DIR_FG}/summary.md" ]]; then
+    if grep -q "Guardian Summary\|Agent Summary" "${TRACE_DIR_FG}/summary.md" 2>/dev/null; then
+        pass_test
+    else
+        fail_test "summary.md written but unexpected content: $(head -2 "${TRACE_DIR_FG}/summary.md")"
+    fi
+else
+    fail_test "fallback did not write summary.md for foreground guardian dispatch at ${TRACE_DIR_FG}/summary.md"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: Foreground dispatch with run_in_background=false behaves same as absent
+# ---------------------------------------------------------------------------
+run_test "FG dispatch: run_in_background=false also goes through fallback"
+
+TEST_DIR=$(mktemp -d "$PROJECT_ROOT/tmp/test-ptbg-XXXXXX")
+_CLEANUP_DIRS+=("$TEST_DIR")
+SESSION_ID="test-fg-false-$$"
+
+TRACE_ID=$(setup_bg_trace_env "planner" "$TEST_DIR" "$SESSION_ID")
+TRACE_DIR_FALSE="${TEST_DIR}/traces/${TRACE_ID}"
+
+REAL_ROOT=$(bash -c "source '$HOOKS_DIR/source-lib.sh' && detect_project_root 2>/dev/null" 2>/dev/null || echo "$PROJECT_ROOT")
+
+printf '{"tool_name":"Agent","tool_input":{"subagent_type":"planner","run_in_background":false},"cwd":"%s"}' \
+    "$REAL_ROOT" \
+    | env TRACE_STORE="${TEST_DIR}/traces" \
+          CLAUDE_SESSION_ID="$SESSION_ID" \
+          CLAUDE_DIR="$TEST_DIR/.claude" \
+      bash "$HOOKS_DIR/post-task.sh" >/dev/null 2>&1 || true
+
+if [[ -f "${TRACE_DIR_FALSE}/summary.md" ]]; then
+    if grep -q "Planner Summary\|Agent Summary" "${TRACE_DIR_FALSE}/summary.md" 2>/dev/null; then
+        pass_test
+    else
+        fail_test "summary.md written but unexpected content: $(head -2 "${TRACE_DIR_FALSE}/summary.md")"
+    fi
+else
+    fail_test "fallback did not write summary.md for fg planner (run_in_background=false) at ${TRACE_DIR_FALSE}/summary.md"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: BG dispatch does NOT write summary.md (the subagent will do that)
+#
+# The subagent is still running — writing a diagnostic summary now would be
+# premature and could be overwritten when the real summary arrives.
+# ---------------------------------------------------------------------------
+run_test "BG dispatch: diagnostic summary NOT written (subagent still running)"
+
+TEST_DIR=$(mktemp -d "$PROJECT_ROOT/tmp/test-ptbg-XXXXXX")
+_CLEANUP_DIRS+=("$TEST_DIR")
+SESSION_ID="test-bg-nosummary-$$"
+
+TRACE_ID=$(setup_bg_trace_env "implementer" "$TEST_DIR" "$SESSION_ID")
+TRACE_DIR_BG="${TEST_DIR}/traces/${TRACE_ID}"
+
+REAL_ROOT=$(bash -c "source '$HOOKS_DIR/source-lib.sh' && detect_project_root 2>/dev/null" 2>/dev/null || echo "$PROJECT_ROOT")
+
+printf '{"tool_name":"Task","tool_input":{"subagent_type":"implementer","run_in_background":true},"cwd":"%s"}' \
+    "$REAL_ROOT" \
+    | env TRACE_STORE="${TEST_DIR}/traces" \
+          CLAUDE_SESSION_ID="$SESSION_ID" \
+          CLAUDE_DIR="$TEST_DIR/.claude" \
+      bash "$HOOKS_DIR/post-task.sh" >/dev/null 2>&1 || true
+
+# No summary.md should exist — the subagent will write it when it completes
+if [[ ! -f "${TRACE_DIR_BG}/summary.md" ]]; then
+    pass_test
+else
+    fail_test "diagnostic summary was written for bg dispatch (premature — subagent still running)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: Static check — @decision annotation exists in post-task.sh
+# ---------------------------------------------------------------------------
+run_test "post-task.sh has @decision DEC-POST-TASK-BG-DISPATCH-001 annotation"
+if grep -q 'DEC-POST-TASK-BG-DISPATCH-001' "$HOOKS_DIR/post-task.sh" 2>/dev/null; then
+    pass_test
+else
+    fail_test "@decision DEC-POST-TASK-BG-DISPATCH-001 not found in post-task.sh"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: Static check — post-task.sh checks tool_input.run_in_background
+# ---------------------------------------------------------------------------
+run_test "post-task.sh reads tool_input.run_in_background to detect bg dispatch"
+if grep -q 'run_in_background' "$HOOKS_DIR/post-task.sh" 2>/dev/null; then
+    pass_test
+else
+    fail_test "post-task.sh does not check tool_input.run_in_background"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: Syntax check
+# ---------------------------------------------------------------------------
+run_test "post-task.sh: valid bash syntax after fix"
+if bash -n "$HOOKS_DIR/post-task.sh" 2>/dev/null; then
+    pass_test
+else
+    fail_test "post-task.sh has syntax errors after fix"
+fi
+
+# ---------------------------------------------------------------------------
+# Final summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $TESTS_PASSED passed, $TESTS_FAILED failed, $TESTS_RUN total"
+echo ""
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- `PostToolUse:Task` was firing `finalize_trace` the moment a `run_in_background: true` Task call returned its agentId — deleting the `.active-<type>-<sid>-<phash>` marker while the subagent was still running.
- `pre-write.sh` Gate 1.5 then saw no marker for the background subagent and blocked every `Write`/`Edit` with *"Source writes from orchestrator context"*, making every background-dispatched implementer unable to write source.
- Fix gates the existing fallback finalize block on `tool_input.run_in_background != true`. `SubagentStop` remains the canonical finalize event for background subagents. Foreground dispatches go through the existing path unchanged.

## Files

- `hooks/post-task.sh` — +55 / -10. Original fallback path preserved verbatim under `else`; `@decision DEC-POST-TASK-BG-DISPATCH-001` annotates the new guard with rationale, discriminator chosen, risk, and future-work pointer.
- `tests/test-post-task-bg-dispatch.sh` — +300, new. 7 tests exercising real `post-task.sh` against crafted `HOOK_INPUT` and real `TRACE_STORE` fixtures (no internal mocks).

## Test plan

- [x] `bash -n hooks/post-task.sh` — passes
- [x] `bash tests/test-post-task-bg-dispatch.sh` — 7/7 pass
  - BG dispatch: active marker survives (finalize_trace skipped)
  - FG dispatch: fallback path still fires (summary.md written)
  - FG dispatch with `run_in_background=false` explicit: goes through fallback
  - BG dispatch: diagnostic summary NOT written (subagent still running)
  - `@decision DEC-POST-TASK-BG-DISPATCH-001` present
  - `post-task.sh` reads `tool_input.run_in_background` for discrimination
  - Syntax check after fix
- [x] Pre-existing tests (`test-post-task-fallback.sh`): no new failures (5 pass, 8 pre-existing failures unrelated to this change)
- [ ] Live end-to-end: dispatch a real background implementer post-merge and confirm marker survives until `SubagentStop` fires. (Requires merge before it can run against the live hook path.)

## Risk

If `SubagentStop` fails to fire for a background subagent, the marker leaks until session end. This is a benign false-allow (Gate 1.5 lets writes through from a context that already wasn't an implementer) — strictly better than the pre-existing false-deny (blocks all writes from a real implementer). Mitigation: a periodic stale-marker sweep in `session-end.sh` keyed off `trace-lib.sh`'s `stale_threshold` (1800s default). Noted as future work in the `@decision`; out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)