### PR TITLE
fix(context-lib): GNU-first stat ordering + numeric guard for Windows portability

### DIFF
--- a/hooks/context-lib.sh
+++ b/hooks/context-lib.sh
@@ -92,7 +92,18 @@ get_plan_status() {
 
     # Plan age
     local plan_mod
-    plan_mod=$(stat -f '%m' "$root/MASTER_PLAN.md" 2>/dev/null || stat -c '%Y' "$root/MASTER_PLAN.md" 2>/dev/null || echo "0")
+    # @decision DEC-CONTEXT-LIB-STAT-PORTABILITY-001
+    # @title GNU-first stat ordering + mandatory numeric guard for plan_mod
+    # @status accepted
+    # @rationale The original BSD-first chain assumed stat -f fails on GNU systems,
+    #   but Windows git bash (GNU coreutils) treats -f as --file-system and succeeds,
+    #   emitting multi-line filesystem text. plan_mod then held that text, and the
+    #   [[ -gt 0 ]] arithmetic context threw: File: unbound variable (set -u).
+    #   Fix: (1) GNU stat -c '%Y' first (correct on Linux AND Windows git bash);
+    #   (2) mandatory numeric guard so any non-integer output is forced to 0 before
+    #   arithmetic use -- the guard is the real robustness fix, not just reordering.
+    plan_mod=$(stat -c '%Y' "$root/MASTER_PLAN.md" 2>/dev/null || stat -f '%m' "$root/MASTER_PLAN.md" 2>/dev/null || echo "0")
+    [[ "$plan_mod" =~ ^[0-9]+$ ]] || plan_mod=0
     if [[ "$plan_mod" -gt 0 ]]; then
         local now
         now=$(date +%s)
@@ -380,9 +391,22 @@ current_workflow_id() {
 }
 
 # --- Cross-platform filesystem helpers ---
+# @decision DEC-CONTEXT-LIB-STAT-PORTABILITY-001
+# @title (see get_plan_status) -- same GNU-first stat + numeric guard pattern
+# @status accepted
+# @rationale file_mtime() had the identical BSD-first ordering bug: stat -f on
+#   Windows git bash (GNU) interprets -f as --file-system and succeeds, returning
+#   filesystem info text. Callers that pass the result to arithmetic (check-guardian.sh
+#   does AGE=$((NOW - MOD_TIME))) would crash or produce garbage. Fix: GNU-first
+#   ordering plus in-function numeric validation so the return value is always a
+#   clean integer (0 for missing/unstateable, epoch for success).
 file_mtime() {
     local path="$1"
-    stat -f '%m' "$path" 2>/dev/null || stat -c '%Y' "$path" 2>/dev/null || echo "0"
+    local _mtime
+    _mtime=$(stat -c '%Y' "$path" 2>/dev/null || stat -f '%m' "$path" 2>/dev/null || echo "0")
+    [[ "$_mtime" =~ ^[0-9]+$ ]] || _mtime=0
+    printf '%s
+' "$_mtime"
 }
 
 # --- Evaluation state (TKT-024: sole readiness authority) ---

--- a/hooks/tests/test-stat-portability.sh
+++ b/hooks/tests/test-stat-portability.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Regression test for DEC-CONTEXT-LIB-STAT-PORTABILITY-001
+# @decision DEC-TEST-CTX-STAT-001
+# @title Regression: stat -f on GNU/Windows returns filesystem text not mtime epoch
+# @status accepted
+# @rationale Covers: (1) get_plan_status no unbound-variable + integer outputs;
+#   (2) numeric guard logic with simulated bad-stat output; (3) file_mtime()
+#   returns clean integer; (4) session-init.sh full chain no unbound variable.
+
+HOOKS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_integer() {
+    local name="$1" val="$2"
+    if [[ "$val" =~ ^[0-9]+$ ]]; then pass "$name is integer: $val";
+    else fail "$name is NOT integer: $(printf '%q' "$val")"; fi
+}
+assert_no_unbound() {
+    local name="$1" s="$2"
+    if [[ "$s" != *"unbound variable"* ]]; then pass "$name: no unbound variable";
+    else fail "$name: unbound variable on stderr: $s"; fi
+}
+assert_not_has() {
+    local name="$1" h="$2" n="$3"
+    if [[ "$h" != *"$n"* ]]; then pass "$name does not contain: $n";
+    else fail "$name CONTAINS: $n"; fi
+}
+
+TMPDIR_BASE=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+GIT_OPTS=(-c user.email="t@t.com" -c user.name="T")
+
+REPO="$TMPDIR_BASE/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" "${GIT_OPTS[@]}" commit --allow-empty -m "init" -q
+printf '%s
+' '# Plan' '' '## Phase 1' '**Status:** completed' > "$REPO/MASTER_PLAN.md"
+
+detect_project_root() { echo "${_TEST_ROOT:-$PWD}"; }
+export -f detect_project_root
+source "$HOOKS_DIR/context-lib.sh"
+
+echo ""
+echo "=== Scenario A: get_plan_status -- integer outputs, no unbound variable ==="
+_TEST_ROOT="$REPO"
+CAPS=$(get_plan_status "$REPO" 2>&1 >/dev/null)
+get_plan_status "$REPO"
+assert_no_unbound "get_plan_status" "$CAPS"
+assert_integer "PLAN_AGE_DAYS" "$PLAN_AGE_DAYS"
+assert_integer "PLAN_TOTAL_PHASES" "$PLAN_TOTAL_PHASES"
+assert_integer "PLAN_COMPLETED_PHASES" "$PLAN_COMPLETED_PHASES"
+assert_integer "PLAN_IN_PROGRESS_PHASES" "$PLAN_IN_PROGRESS_PHASES"
+assert_integer "PLAN_COMMITS_SINCE" "$PLAN_COMMITS_SINCE"
+[[ "$PLAN_EXISTS" == "true" ]] && pass "PLAN_EXISTS=true" || fail "PLAN_EXISTS not true"
+[[ "$PLAN_AGE_DAYS" -le 1 ]] && pass "PLAN_AGE_DAYS reasonable" || fail "PLAN_AGE_DAYS too large: $PLAN_AGE_DAYS"
+
+echo ""
+echo "=== Scenario B: numeric guard forces bad stat output to 0 ==="
+# Simulate Windows git bash stat -f output (GNU stat --file-system output):
+BAD="  File: /c/Users/foo/MASTER_PLAN.md  ID: 0 Namelen: 255 Type: NTFS"
+PM="$BAD"
+[[ "$PM" =~ ^[0-9]+$ ]] || PM=0
+[[ "$PM" =~ ^[0-9]+$ ]] && pass "guard result is integer" || fail "guard result not integer"
+[[ "$PM" -eq 0 ]] && pass "bad stat output forced to 0" || fail "expected 0, got: $PM"
+# The File: prefix was the exact token that caused set -u crash:
+SFP="File: some/path"
+[[ "$SFP" =~ ^[0-9]+$ ]] || SFP=0
+[[ "$SFP" -gt 0 ]] 2>/dev/null && fail "guard should have given 0" || pass "File: prefix guarded correctly"
+
+echo ""
+echo "=== Scenario C: file_mtime() -- clean integer ==="
+MERR="$TMPDIR_BASE/merr"
+MOUT=$(file_mtime "$REPO/MASTER_PLAN.md" 2>"$MERR")
+MERRC=$(cat "$MERR" 2>/dev/null || true); rm -f "$MERR"
+assert_integer "file_mtime output" "$MOUT"
+assert_no_unbound "file_mtime" "$MERRC"
+[[ "$MOUT" -gt 0 ]] && pass "file_mtime positive epoch" || fail "expected positive epoch, got: $MOUT"
+MMISS=$(file_mtime "$REPO/NO_SUCH_FILE" 2>/dev/null)
+assert_integer "file_mtime missing file" "$MMISS"
+[[ "$MMISS" -eq 0 ]] && pass "file_mtime missing=0" || fail "expected 0, got: $MMISS"
+
+echo ""
+echo "=== Scenario D: session-init.sh -- full chain no unbound variable ==="
+HERR="$TMPDIR_BASE/herr"
+SESSION_JSON="{"session_id":"t","cwd":"$REPO","hook_event_name":"SessionStart"}"
+HOUT=$(printf '%s' "$SESSION_JSON" | CLAUDE_PROJECT_DIR="$REPO" bash "$HOOKS_DIR/session-init.sh" 2>"$HERR")
+HEXIT=$?
+HERRC=$(cat "$HERR"); rm -f "$HERR"
+[[ "$HEXIT" -eq 0 ]] && pass "session-init exits 0" || fail "session-init exits $HEXIT"
+assert_no_unbound "session-init.sh" "$HERRC"
+assert_not_has "session-init stderr" "$HERRC" "File: unbound variable"
+[[ -n "$HERRC" ]] && { echo "    stderr:"; echo "$HERRC" | head -3 | sed "s/^/    /"; }
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

`hooks/context-lib.sh` resolved `MASTER_PLAN.md` mtime with a BSD-first `||` chain: `stat -f '%m' || stat -c '%Y'`. The chain assumes the BSD form *fails* on GNU systems so it falls through to the GNU form.

On **Windows git bash** (GNU coreutils), `stat -f` means `--file-system` and is a *valid* flag — `stat -f '%m' <file>` **succeeds (exit 0)** and prints filesystem text starting with `File:`. The `|| stat -c '%Y'` fallback is never reached. `plan_mod` ends up holding multi-line filesystem text instead of an epoch.

Line 96's `[[ "$plan_mod" -gt 0 ]]` then arithmetic-evaluates the operand; bash treats the bareword `File` as a variable name, it's unset, and `set -u` throws:

```
hooks/context-lib.sh: line 96: File: unbound variable
```

This fired on **every session start** where a `MASTER_PLAN.md` exists. Non-fatal (`session-init.sh` still exits 0), but it's stderr noise on every session and the plan-staleness signals (`PLAN_AGE_DAYS`, `PLAN_COMMITS_SINCE`, `PLAN_CHANGED_SOURCE_FILES`, `PLAN_SOURCE_CHURN_PCT`) were all silently wrong/zero on Windows.

Confirmed live on Windows 11 / git bash / GNU coreutils stat.

## Fix (`@decision DEC-CONTEXT-LIB-STAT-PORTABILITY-001`)

Two call sites had the identical BSD-first bug:
- `get_plan_status()` — `plan_mod` resolution
- `file_mtime()` — same pattern; its result feeds arithmetic in `check-guardian.sh` (`AGE=$((NOW - MOD_TIME))`)

Both fixed with:
1. **GNU-first ordering** — `stat -c '%Y'` first (correct on Linux *and* Windows git bash), `stat -f '%m'` second (macOS fallback).
2. **Mandatory numeric guard** — `[[ "$x" =~ ^[0-9]+$ ]] || x=0` before any arithmetic use. This is the real robustness fix: reordering alone wouldn't protect against a future `stat` variant emitting non-numeric output into an arithmetic context.

`date -r` / `date -d @` on line 105 was surveyed and left as-is — GNU `date -r <number>` treats the arg as a filename, fails cleanly with exit 1, and falls through to `date -d @<number>`. Not buggy; noted in the survey.

## Test plan

- [x] `bash -n hooks/context-lib.sh` — clean
- [x] New `hooks/tests/test-stat-portability.sh` — 19 assertions, 19 pass (covers GNU-first resolution, the non-numeric-output regression path forcing `0`, `file_mtime` missing-file=0, and a full `session-init.sh` chain assertion that stderr contains no `unbound variable`)
- [x] Pre-existing tests still pass: `test-context-lib.sh`, `test-context-lib-lease-first.sh`, `test-lease-session-context.sh`
- [x] Live repro before/after: `session-init.sh` with a `MASTER_PLAN.md` present — stderr went from `context-lib.sh: line 96: File: unbound variable` to empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)